### PR TITLE
Fix device handling for training

### DIFF
--- a/dqn.py
+++ b/dqn.py
@@ -5,20 +5,21 @@ from static_parameters import LR, GAMMA
 
 
 class DQN(nn.Module):
-    def __init__(self, model):
+    def __init__(self, model, device):
         super().__init__()
         self.lr = LR
         self.gamma = GAMMA
-        self.model = model
-        self.optimizer = optim.AdamW(model.parameters(), lr=self.lr)
+        self.device = device
+        self.model = model.to(self.device)
+        self.optimizer = optim.AdamW(self.model.parameters(), lr=self.lr)
         self.criterion = nn.MSELoss()
 
     def train_step(self, state, action, reward, next_state, done):
         # 把state都用tensor来表示
-        state = torch.tensor(state, dtype=torch.float).cuda()
-        next_state = torch.tensor(next_state, dtype=torch.float).cuda()
-        action = torch.tensor(action, dtype=torch.long).cuda()
-        reward = torch.tensor(reward, dtype=torch.float).cuda()
+        state = torch.tensor(state, dtype=torch.float, device=self.device)
+        next_state = torch.tensor(next_state, dtype=torch.float, device=self.device)
+        action = torch.tensor(action, dtype=torch.long, device=self.device)
+        reward = torch.tensor(reward, dtype=torch.float, device=self.device)
 
         if len(state.shape) == 1: # 短期记忆
             state = torch.unsqueeze(state, 0)

--- a/starter.py
+++ b/starter.py
@@ -8,7 +8,10 @@ if __name__ == '__main__':
     use_gpu = torch.cuda.is_available()
 
     # Decide which device we want to run on
-    print(torch.cuda.get_device_name(0))
+    if use_gpu:
+        print(torch.cuda.get_device_name(0))
+    else:
+        print("Running on CPU")
 
     agent = Agent()
     agent.train()


### PR DESCRIPTION
## Summary
- handle CPU or GPU selection
- update DQN to work with specified device
- adjust starter script for missing GPUs

## Testing
- `python -m py_compile agent.py dqn.py starter.py`
- `python starter.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6880df566e38832791fdda309d1460c5