### PR TITLE
Fix DQN target gradient calculation

### DIFF
--- a/dqn.py
+++ b/dqn.py
@@ -36,7 +36,9 @@ class DQN(nn.Module):
             if done[i]:
                 Q_new = reward[i]
             else:
-                Q_new = reward[i] + self.gamma * torch.max(self.model(torch.unsqueeze(next_state[i], 0)))
+                with torch.no_grad():
+                    next_q = self.model(torch.unsqueeze(next_state[i], 0))
+                    Q_new = reward[i] + self.gamma * torch.max(next_q)
 
             target[i][action[i]] = Q_new
 


### PR DESCRIPTION
## Summary
- prevent gradient flow through target Q-value calculation in `train_step`
- ensure newline at end of `dqn.py`

## Testing
- `python3 -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880df545f94832788c8042e4b671572