### PR TITLE
Improve DQN reward with distance-based shaping

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -126,20 +126,20 @@ class Agent:
                         try:
                             eaten = self.game.move(action)
                         except IllegalMoveError:
-                            reward = -20
+                            reward = -2
                             done = True
                         except TimeoutError:
-                            reward = -25
+                            reward = -2.5
                             done = True
                         else:
                             if self.epoch % SHOW == 0:
                                 self.update_ui()
                             new_distance = abs(self.game.p - self.game.i) + abs(self.game.q - self.game.j)
                             distance_change = old_distance - new_distance
-                            reward = 40 * int(eaten)
+                            reward = 4 * int(eaten)
                             if not eaten:
                                 # 密集奖励：根据距离变化给予奖励并施加小的时间惩罚
-                                reward += distance_change - 0.1
+                                reward += 0.1 * distance_change - 0.01
                             next_state = self.game.get_state()
                         self.train_short_memory(state, action, reward, next_state, done)
                     if self.epoch % SHOW == 0:

--- a/agent.py
+++ b/agent.py
@@ -135,13 +135,11 @@ class Agent:
                             if self.epoch % SHOW == 0:
                                 self.update_ui()
                             new_distance = abs(self.game.p - self.game.i) + abs(self.game.q - self.game.j)
+                            distance_change = old_distance - new_distance
                             reward = 40 * int(eaten)
                             if not eaten:
-                                # 简单奖励：靠近食物奖励，远离食物惩罚
-                                if new_distance < old_distance:
-                                    reward += 1
-                                else:
-                                    reward -= 1
+                                # 密集奖励：根据距离变化给予奖励并施加小的时间惩罚
+                                reward += distance_change - 0.1
                             next_state = self.game.get_state()
                         self.train_short_memory(state, action, reward, next_state, done)
                     if self.epoch % SHOW == 0:

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -20,19 +20,19 @@ def compute_reward(game, action):
     eaten = game.move(action)
     new_distance = abs(game.p - game.i) + abs(game.q - game.j)
     distance_change = old_distance - new_distance
-    reward = 40 * int(eaten)
+    reward = 4 * int(eaten)
     if not eaten:
-        reward += distance_change - 0.1
+        reward += 0.1 * distance_change - 0.01
     return reward
 
 
 def test_reward_increases_when_closer_to_food():
     game = setup_game((5, 5), (5, 7))
     reward = compute_reward(game, 3)  # move right toward food
-    assert reward == pytest.approx(0.9)
+    assert reward == pytest.approx(0.09)
 
 
 def test_reward_decreases_when_farther_from_food():
     game = setup_game((5, 5), (5, 7))
     reward = compute_reward(game, 2)  # move left away from food
-    assert reward == pytest.approx(-1.1)
+    assert reward == pytest.approx(-0.11)

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from collections import deque
 
 from snake_game import SnakeGame
@@ -18,22 +19,20 @@ def compute_reward(game, action):
     old_distance = abs(game.p - game.i) + abs(game.q - game.j)
     eaten = game.move(action)
     new_distance = abs(game.p - game.i) + abs(game.q - game.j)
+    distance_change = old_distance - new_distance
     reward = 40 * int(eaten)
     if not eaten:
-        if new_distance < old_distance:
-            reward += 1
-        else:
-            reward -= 1
+        reward += distance_change - 0.1
     return reward
 
 
 def test_reward_increases_when_closer_to_food():
     game = setup_game((5, 5), (5, 7))
     reward = compute_reward(game, 3)  # move right toward food
-    assert reward == 1
+    assert reward == pytest.approx(0.9)
 
 
 def test_reward_decreases_when_farther_from_food():
     game = setup_game((5, 5), (5, 7))
     reward = compute_reward(game, 2)  # move left away from food
-    assert reward == -1
+    assert reward == pytest.approx(-1.1)


### PR DESCRIPTION
## Summary
- Incorporate dense reward shaping in `Agent.train` based on Manhattan distance change with a small time penalty
- Update reward tests to reflect new shaping and use `pytest.approx`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689c49c41450832794cf962b9569db5c